### PR TITLE
Update Drush to 8.4.12 & QOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN chmod +rx /usr/bin/drush
 
 # Install Drush 8.* globally for D6, D7, D8.3-
 # for D8.4+ use Drupal Composer site project with Drush listed as a dependency
-ADD https://github.com/drush-ops/drush/releases/download/8.4.8/drush.phar /opt/drush
+ADD https://github.com/drush-ops/drush/releases/download/8.4.12/drush.phar /opt/drush
 RUN chmod +rx /opt/drush
 
 # Add Acquia Cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,9 @@ RUN chmod +x /usr/local/bin/oh-my-posh && \
 COPY ./config /home/vscode/.config/
 RUN chown -R vscode:vscode /home/vscode/.config
 
+# Zsh Startup
+RUN echo startup.sh >> /home/vscode/.zshrc
+
 # Based on https://github.com/docker-library/drupal/blob/master/9.2/php8.0/apache-buster/Dockerfile
 # install the PHP extensions we need
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.created=$CREATE_DATE
 ENV APACHE_SERVER_NAME="localhost"
 ENV APACHE_DOCUMENT_ROOT "docroot"
 ENV WORKSPACE_ROOT "/var/www/html"
+ENV DCR "/var/www/html/docroot"
 ENV WR "/var/www/html"
 # Default theme
 ENV POSH_THEME_ENVIRONMENT "ys"

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -6,4 +6,7 @@ apache2ctl start
 printf "\n⚒️  Image Details "
 about.sh d | jq
 
+printf "\n💡 Hints"
+echo '{"$WR":"/var/www/html", "$DCR": "/var/www/html/docroot"}' | jq
+
 printf "\n"


### PR DESCRIPTION
- [Drush to 8.4.12 for PHP 8.1 & 8.2 Support](https://github.com/alchatti/drupal-devcontainer-image/commit/57e25612b57ee03d5f5b8d3687785ba31ca48170)
- [fix(Dockerfile): 🐛 Add startup.sh when using zsh shell](https://github.com/alchatti/drupal-devcontainer-image/commit/7f2e10dc2fe063f47585f56849382308fc99d30f)
- [feat(Dockerfile): 🧑‍💻 add DCR env variable shortcut to docroot](https://github.com/alchatti/drupal-devcontainer-image/commit/975f0de1c7eda363bf87f8396c7951769cbf32b1)
- [feat: 📝 startup now prints ENV shortcut hints](https://github.com/alchatti/drupal-devcontainer-image/commit/04c8431e7ed055428a1740942ce9d6329b86846f)