### PR TITLE
feat: `git-qucik-stats` & `7.4` retirement with December updates

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php_ver: ["7.4", "8.1", "8.2"]
+        php_ver: ["8.1", "8.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,8 @@ RUN apt update; \
   default-mysql-client \
   gettext-base \
   libpcre2-32-0 \
-  build-essential
+  build-essential \
+  git-quick-stats
 
 # Docker PHP Extensions & Config
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,7 @@ RUN ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
   | sort -u \
   | xargs -rt apt-mark manual
 
-ADD https://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_11/${TARGETARCH}/fish_3.6.1-1_${TARGETARCH}.deb /tmp/fish.deb
+ADD https://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_11/${TARGETARCH}/fish_3.6.4-1_${TARGETARCH}.deb /tmp/fish.deb
 RUN dpkg -i /tmp/fish.deb
 
 USER vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Based on https://github.com/docker-library/drupal/blob/master/9.2/php8.0/apache-bullseye/Dockerfile file
 # Uses mcr.microsoft.com/vscode/devcontainers/php as base image
 # For list of tags vsist https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list
+# Relesases code names at https://wiki.debian.org/DebianReleases#Production_Releases
 
 ARG VARIANT
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ With the following additional packages:
 	- [fish](https://fishshell.com/)
 	- [Oh My Posh](https://ohmyposh.dev/) for Zsh & Fish
 
+- Git enhancements:
+	- [git-quick-stats](https://github.com/arzzen/git-quick-stats) a simple and efficient way to access various statistics in a git repository
+
 ## Environment variables
 
 The following are environment variables for customization.
@@ -177,6 +180,12 @@ The workflow is set on schedule and triggered on push to the main branch. It als
 - Image issues, details, source https://github.com/alchatti/drupal-devcontainer-image
 
 ## Change logs
+
+### December 2023
+
+- feat: `git-quick-stats` added to the image.
+- feat: `fish` updated to  `3.6.4-1`.
+- feat: `about` script to prints base image OS version.
 
 ### January 2023
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ Available tags:
 
 - `8.2`: PHP 8.2 with latest Node.js, and Composer at build.
 - `8.1`: PHP 8.1 with latest Node.js, and Composer at build.
-- `7.4`: PHP 7.4 with latest Node.js, and Composer at build.
+
+Legacy / Deprecated tags:
+
+- `7.4`: PHP 7.4 with latest Node.js, and Composer at build. (last build 2023DEC01)
 
 You can also use timestamped tags to target a specific build. Check https://hub.docker.com/r/alchatti/drupal-devcontainer/tags for available tags.
 
@@ -186,6 +189,7 @@ The workflow is set on schedule and triggered on push to the main branch. It als
 - feat: `git-quick-stats` added to the image.
 - feat: `fish` updated to  `3.6.4-1`.
 - feat: `about` script to prints base image OS version.
+- feat: retired `7.4` PHP version.
 
 ### January 2023
 

--- a/scripts/about.sh
+++ b/scripts/about.sh
@@ -15,6 +15,8 @@ BuildInfo=$(cat /var/.buildInfo)
 
 TAG="$vr_php_major.$vr_php_minor"
 
+OSInfo=$(cat /etc/os-release | grep PRETTY_NAME | awk -F\" '{print $2}')
+
 if [ $vr_node_lts == "undefined" ]
 then
 	TAG_N="n$vr_node_major"
@@ -30,6 +32,6 @@ TAG_L=$vr_php-n$vr_node-c$vr_composer-npm$vr_npm
 case $1 in
 	s) echo $TAG_S;;
 	l) echo $TAG_L;;
-	d) echo '{ "PHP":"'$vr_php'", "NodeJs":"'$vr_node'", "npm":"'$vr_npm'", "Composer":"'$vr_composer'", "Build Date": "'$BuildInfo'" }';;
+	d) echo '{ "OS":"'$OSInfo'", "PHP":"'$vr_php'", "NodeJs":"'$vr_node'", "npm":"'$vr_npm'", "Composer":"'$vr_composer'", "Build Date": "'$BuildInfo'" }';;
 	*) echo '{ "TAG":"'$TAG'", "TAG_S": "'$TAG_S'", "TAG_L": "'$TAG_L'"}' ;;
 esac


### PR DESCRIPTION
Changelog as follow:

- #19  
- feat: `fish` updated to  `3.6.4-1`.
- feat: `about` script to prints base image OS version. 
- #20