### PR TITLE
Jan 2024 update

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -13,10 +13,8 @@ on:
   #   paths-ignore: ['**.md']
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  # Run on Monday
   schedule:
-    - cron: '0 3 3 * *'
-  # - cron: '0 0 * * WED'
+    - cron: "0 3 3 * *"
 
 jobs:
   build:
@@ -32,26 +30,26 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y%m%d')"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker Login
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: GitHub Container Registry Login
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.PKG_GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG VARIANT
 
-FROM mcr.microsoft.com/vscode/devcontainers/php:0-${VARIANT}-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/php:${VARIANT}-bookworm
 
 ARG VARIANT
 ARG CREATE_DATE

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,12 @@ RUN echo startup.sh >> /home/vscode/.zshrc
 RUN \
   a2enmod rewrite
 
+# Packages & Repositories
+
+## Add Fish to sources
+RUN echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_12/ /' | sudo tee /etc/apt/sources.list.d/shells:fish:release:3.list; \
+  curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_12/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
+
 RUN apt update; \
   apt install -y --no-install-recommends \
   libfreetype6-dev \
@@ -129,7 +135,9 @@ RUN apt update; \
   gettext-base \
   libpcre2-32-0 \
   build-essential \
-  git-quick-stats
+  git-quick-stats \
+  fish \
+  ;
 
 # Docker PHP Extensions & Config
 RUN set -eux; \
@@ -156,8 +164,6 @@ RUN ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
   | sort -u \
   | xargs -rt apt-mark manual
 
-ADD https://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_11/${TARGETARCH}/fish_3.6.4-1_${TARGETARCH}.deb /tmp/fish.deb
-RUN dpkg -i /tmp/fish.deb
 
 USER vscode
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can also use timestamped tags to target a specific build. Check https://hub.
 
 ## Image
 
-The image is targeting the latest 7 & 8 versions of PHP with latest Node.js.
+The image is targeting the latest 8.1 & 8.2 versions of PHP with latest Node.js.
 
 ## Scripts
 
@@ -183,6 +183,16 @@ The workflow is set on schedule and triggered on push to the main branch. It als
 - Image issues, details, source https://github.com/alchatti/drupal-devcontainer-image
 
 ## Change logs
+
+### January 2024
+
+- feat: base image updated to Debian 12 (Bookworm).
+- feat: `fish` now uses repository for installation.
+- feat: github/actions updated as follows:
+ 	- actions/checkout@v`2`->`3`
+ 	- docker/setup-qemu-action@v`2`->`3`
+ 	- docker/setup-buildx-action@v`2.0.0`->`3`
+ 	- docker/build-push-action@v`3`->`5`
 
 ### December 2023
 

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ done
 if [ -z "$PHP" ]
 then
   # PHP=("7" "8.0" "8.1")
-  PHP=("7.4" "8.1")
+  PHP=("8.1" "8.2")
   printf "- No PHP version setting defaulting to 7 and 8 \n\n"
 fi;
 


### PR DESCRIPTION
Happy New Year🎉

This pull request updates the following:

- Set build to be 3rd day of the month instead of first, avoid new year.
- Updated base image to Ubuntu Debian 12 (Bookworm) #23.
- `fish` now uses repo and will auto update to latest version #22.
- `build-and-push-actions` updated to the latest for each action version.