### PR TITLE
doc: added Xdebug port note

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Dev feature are set for the container user `vscode`, a none root user provided b
 
 > Apache server will start as part of the a startup script using command `apache2ctl start`
 
+> Xdebug port is `9003`, the [default client port] (https://xdebug.org/docs/all_settings#client_port).
+
 ### Quick Start: Self contained Drupal site for testing & Demonstration
 
 Drupal 10 can be installed with SQLite without the need for an additional database container.
@@ -79,8 +81,6 @@ exit
 ```bash
 docker volume rm drupal-dev-html
 ```
-
-> Xdebug port is 9003, which the default value.
 
 ### Additional usage options & flags
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Dev feature are set for the container user `vscode`, a none root user provided b
 
 > Apache server will start as part of the a startup script using command `apache2ctl start`
 
-> Xdebug port is `9003`, the [default client port] (https://xdebug.org/docs/all_settings#client_port).
+>Xdebug port is `9003`, the [default client port](https://xdebug.org/docs/all_settings#client_port).
 
 ### Quick Start: Self contained Drupal site for testing & Demonstration
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ exit
 docker volume rm drupal-dev-html
 ```
 
+> Xdebug port is 9003, which the default value.
+
 ### Additional usage options & flags
 
 - Change the shell to `zsh` and the theme to 'blue-owl' by using environment variable `POSH_THEME_ENVIRONMENT`, for more theme options check [Oh My Posh theme](https://ohmyposh.dev/docs/themes).


### PR DESCRIPTION
Updated README.md with Xdebug default port configuration for developer convenience.

Related to #32